### PR TITLE
Feature/request optimizations

### DIFF
--- a/Portfolio/Services/LangTablePreCacher.cs
+++ b/Portfolio/Services/LangTablePreCacher.cs
@@ -24,6 +24,6 @@ public class LangTablePreCacher
         var uris = _infoGetter.Data.Keys;
         uris = uris.Concat(Extra);
 
-        return await _langTable.PreCacheAll(uris, langCode);
+        return _langTable.PreCacheAll(uris, langCode);
     }
 }

--- a/Portfolio/Services/LangTablePreCacher.cs
+++ b/Portfolio/Services/LangTablePreCacher.cs
@@ -18,12 +18,12 @@ public class LangTablePreCacher
         _infoGetter = infoGetter;
     }
 
-    public async Task<bool> PreCache(int langCode)
+    public async Task PreCache(int langCode)
     {
         await _infoGetter.RetrieveData();
         var uris = _infoGetter.Data.Keys;
         uris = uris.Concat(Extra);
 
-        return _langTable.PreCacheAll(uris, langCode);
+        _langTable.PreCacheAll(uris, langCode);
     }
 }


### PR DESCRIPTION
Hierin heb ik nog eens goed gekeken naar mijn io operations, om specifiek te zijn: de project-pagina content.
Deze werd voorheen niet in parallel opgevraagd, maar wachtte de requests altijd op elkaar. Nu wordt het wel in parallel uitgevoerd, en hoeft er ook niet meer gecheckt te worden op failure. De specifieke failure die plaats kon vinden was toch al non-recoverable; dus waarom er dan voor checken